### PR TITLE
Added the functionality to activate and deactivate numlock in the cinnamon interface

### DIFF
--- a/usr/share/biglinux/biglinux-settings/usability/numLock.sh
+++ b/usr/share/biglinux/biglinux-settings/usability/numLock.sh
@@ -20,12 +20,13 @@ if [ "$1" == "check" ]; then
 #     else
 #       echo "false"
 #     fi
-#   elif [[ "$XDG_CURRENT_DESKTOP" == *"Cinnamon"* ]] || [[ "$XDG_CURRENT_DESKTOP" == *"X-Cinnamon"* ]];then
-#     if [[ "$someTest" == "true" ]];then
-#       echo "true"
-#     else
-#       echo "false"
-#     fi
+  elif [[ "$XDG_CURRENT_DESKTOP" == *"Cinnamon"* ]] || [[ "$XDG_CURRENT_DESKTOP" == *"X-Cinnamon"* ]];then
+    recent_status=$(gsettings get org.cinnamon.desktop.peripherals.keyboard numlock-state)
+    if [[ "$recent_status" == "true" ]]; then
+      echo "true"
+    else
+      echo "false"
+    fi
   fi
 
 # change the state
@@ -42,7 +43,7 @@ elif [ "$1" == "toggle" ]; then
         return $?
     fi
 #   elif [[ "$XDG_CURRENT_DESKTOP" == *"GNOME"* ]];then
-#     if [[ "$new_state" == "true" ]];then
+#     if [[ "$state" == "true" ]];then
 #         some command
 #         exitCode=$?
 #     else
@@ -50,21 +51,23 @@ elif [ "$1" == "toggle" ]; then
 #         exitCode=$?
 #     fi
 #   elif [[ "$XDG_CURRENT_DESKTOP" == *"XFCE"* ]];then
-#     if [[ "$new_state" == "true" ]];then
+#     if [[ "$state" == "true" ]];then
 #         some command
 #         exitCode=$?
 #     else
 #         some command
 #         exitCode=$?
 #     fi
-#   elif [[ "$XDG_CURRENT_DESKTOP" == *"Cinnamon"* ]] || [[ "$XDG_CURRENT_DESKTOP" == *"X-Cinnamon"* ]];then
-#     if [[ "$new_state" == "true" ]];then
-#         some command
-#         exitCode=$?
-#     else
-#         some command
-#         exitCode=$?
-#     fi
+  elif [[ "$XDG_CURRENT_DESKTOP" == *"Cinnamon"* ]] || [[ "$XDG_CURRENT_DESKTOP" == *"X-Cinnamon"* ]];then
+    if [[ "$state" == "true" ]];then
+        gsettings set org.cinnamon.desktop.peripherals.keyboard numlock-state true
+        numlockx on
+        exitCode=$?
+    else
+        gsettings set org.cinnamon.desktop.peripherals.keyboard numlock-state false
+        numlockx off 
+        exitCode=$?
+    fi
   fi
   exit $exitCode
 fi


### PR DESCRIPTION
The functionality to activate and deactivate numlock has been added to the cinnamon interface.

**Behavior when marked**
<img width="1128" height="898" alt="image" src="https://github.com/user-attachments/assets/a4626bad-d7c6-4a22-ad5c-0154f04132fc" />

**behavior when unchecked**
<img width="1128" height="913" alt="image" src="https://github.com/user-attachments/assets/dc62bc53-6794-49cb-9cd4-cc597ea7c46e" />
