### PR TITLE
Fix para devices/bluetooth.sh

### DIFF
--- a/usr/share/biglinux/biglinux-settings/devices/bluetooth.sh
+++ b/usr/share/biglinux/biglinux-settings/devices/bluetooth.sh
@@ -3,13 +3,11 @@
 # check current status
 # action=$1
 if [ "$1" == "check" ]; then
-  bluetoothState="$(LANG=C LANGUAGE=C timeout 0.1 bluetoothctl show | grep "Powered:" | awk '{print $2}')"
-  if [[ "$bluetoothState" == "yes" ]];then
-    echo "true"
-  elif [[ "$bluetoothState" == "no" ]];then
-    echo "false"
-  else
-    echo "false"
+  bluetoothState="$(LANG=C LANGUAGE=C timeout 0.1 echo "show" | bluetoothctl | grep "Powe> 
+  if [[ "$bluetoothState" == "yes" ]];then                                                 
+    echo "true"                                                                            
+  else                                                                                     
+    echo "false"                                                                           
   fi
 
 # change the state

--- a/usr/share/biglinux/biglinux-settings/devices/bluetooth.sh
+++ b/usr/share/biglinux/biglinux-settings/devices/bluetooth.sh
@@ -3,7 +3,7 @@
 # check current status
 # action=$1
 if [ "$1" == "check" ]; then
-  bluetoothState="$(LANG=C LANGUAGE=C timeout 0.1 echo "show" | bluetoothctl | grep "Powe> 
+  bluetoothState="$(LANG=C LANGUAGE=C timeout 0.1 echo "show" | bluetoothctl | grep "Powered:" | awk '{print $2}')"
   if [[ "$bluetoothState" == "yes" ]];then                                                 
     echo "true"                                                                            
   else                                                                                     


### PR DESCRIPTION
Aparentemente há uma situação de corrida com o comando bluetoothctl show pois está retornando vazio. Alterei para echo "show" | bluetoothctl e resolveu. Aproveitei e retirei um elseif que não fazia muito sentido ali.