### PR TITLE
Update bluetooth.sh

### DIFF
--- a/usr/share/biglinux/biglinux-settings/devices/bluetooth.sh
+++ b/usr/share/biglinux/biglinux-settings/devices/bluetooth.sh
@@ -3,7 +3,9 @@
 # check current status
 # action=$1
 if [ "$1" == "check" ]; then
-  bluetoothState="$(LANG=C LANGUAGE=C timeout 0.1 echo "show" | bluetoothctl | grep "Powered:" | awk '{print $2}')"
+   set -o pipefail
+   bluetoothState="$(LANG=C LANGUAGE=C echo "show" | timeout 0.1 bluetoothctl | grep "Powered:" | awk '{print $2}')"
+   set +o pipefail
   if [[ "$bluetoothState" == "yes" ]];then                                                 
     echo "true"                                                                            
   else                                                                                     


### PR DESCRIPTION
Com a alteração deste comando, o timeout estava inócuo pois atuava sobre o echo e não sobre o bluetoothctl. De qualquer forma, na versão anterior, este timeout era inócuo também pois como estava num pipe, o código de saída era sempre do último comando executado.

Com esta alteração e com a linha set -o pipefail, o codigo de retorno de erro é de qualquer comando dentro do pipe.

Para testar isso, faça:
echo "show" | timeout 0.000000000001 sort  <- retorna erro
echo "show" | timeout 0.000000000001 sort | ls <- retorna ok

usando set -o pipefail:
echo "show" | timeout 0.000000000001 sort | ls <- retorna erro
